### PR TITLE
exclude widget.py from Code Climate analysis

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -5,3 +5,6 @@ engines:
 ratings:
    paths:
    - "**.py"
+   
+exclude_paths:
+- "*/**/widget.py"


### PR DESCRIPTION
Hi! Emily here from Code Climate Support. Here are the lines you'll need to exclude the widget.py file.